### PR TITLE
Bug in `n1` and `n2` -> `float` to `int` 

### DIFF
--- a/pymodalib/implementations/python/wavelet/wavelet_transform.py
+++ b/pymodalib/implementations/python/wavelet/wavelet_transform.py
@@ -309,7 +309,8 @@ def wavelet_transform(
     else:
         n1 = np.floor((NL - L) * coib1[0] / (coib1[0] + coib2[0]))
         n2 = np.ceil((NL - L) * coib1[0] / (coib1[0] + coib2[0]))
-
+    n1 = int(n1)
+    n2 = int(n2)
     if padding == "predictive":
         pow = (-(L / fs - np.arange(1, L + 1) / fs)) / (wp.t2h - wp.t1h)
         w = 2 ** pow
@@ -498,6 +499,8 @@ def wavelet_transform(
             "cut_edges": cut_edges,
             "fs": fs,
             "padding": padding,
+            "n1": n1,
+            "n2": n2,
             "rel_tolerance": rel_tolerance,
         }
         return WT, freq, opt


### PR DESCRIPTION
When doing constant padding the length is taken from parameters `n1 `and `n2` calculated based on the selection of the mother wavelet. After `np.floor` and `np.ceil` the values of `n1` and `n2` are still `float`. Consequently `np.zeros` raises exception. This is solved by simply casing `n1` and `n2` to `int`.

Second issue is the post processing information how long was the padding. For that purpose I've added the parameters `n1` and `n2` in the `opt` return `dict`.